### PR TITLE
Two more events

### DIFF
--- a/src/ng-pouch-mirror.js
+++ b/src/ng-pouch-mirror.js
@@ -30,7 +30,8 @@ angular.module('pouchMirror', [])
       // First copy the diskDb to memory, and then sync changes in memory to diskDb
       memoryDb = new PouchDB(localDbName + '_mem', {adapter: 'memory'});
       diskDb = new PouchDB(localDbName);
-      diskDb.replicate.to(memoryDb).then(function() {
+      diskDb.replicate.to(memoryDb).on('complete', function(){
+        $rootScope.$broadcast('pm:update', localDbName, 'mem_ready', getStatus());
         memoryDb.replicate.to(diskDb, {live: true});
         startSync();
       });
@@ -103,6 +104,8 @@ angular.module('pouchMirror', [])
               active = false;
               status = 'error';
               $rootScope.$broadcast('pm:error', localDbName, err, getStatus());
+            }).on('change', function(){
+              $rootScope.$broadcast('pm:update', localDbName, 'change', getStatus());
             });
           syncing = true;
           status = 'syncing';


### PR DESCRIPTION
`$rootScope.$broadcast('pm:update', localDbName, 'mem_ready', getStatus());`

to get the documents in a view when memorydb has its documents.
Todocontroller:

```
self.$rootScope.$on("pm:update", function(event, localName, action, syncStatus) {
     if (localName === "todos" && action === "mem_ready") {
        self.GetTodos();
     }
});
```

and 

```
remoteSync.on('change', function(){
  $rootScope.$broadcast('pm:update', localDbName, 'change', getStatus());
})
```

to get updates, if new documents landed in memorydb.
Todocontroller:

```
self.$rootScope.$on("pm:update", function(event, localName, action, syncStatus) {
     if (localName === "todos" && action === "change") {
        self.GetTodos();
     }
});
```

I modified this because the event 'ready' of the remoteSync was too slow on a view, that loads on app-start
